### PR TITLE
Make library browser compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Unicity Commons
 
 A library of common functions to be used in Unicity projects.
+
+## Browser Compatibility
+
+When bundling for the browser, the `NodeDataHasher` implementation is
+automatically replaced by `SubtleCryptoDataHasher` through the `browser`
+field in `package.json`. This allows the hashing utilities to work in
+modern browsers such as Chrome without including Node specific code.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "exports": {
     "./lib/*": "./lib/*"
   },
+  "browser": {
+    "./lib/hash/NodeDataHasher.js": "./lib/hash/SubtleCryptoDataHasher.js"
+  },
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"src/**/*\" \"tests/**/*\"" ,


### PR DESCRIPTION
## Summary
- document browser compatibility in `README.md`
- map `NodeDataHasher` to `SubtleCryptoDataHasher` when bundling for browsers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dbaa1cbd08332a316ee6f5b090745